### PR TITLE
feat: add loan deletion functionality

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import type { LoanApplication } from './types/loan'
-import { getLoans, updateLoanStatus, autoDecideLoan } from './services/loanService'
+import { getLoans, updateLoanStatus, autoDecideLoan, deleteLoan } from './services/loanService'
 import LoanForm from './components/LoanForm.vue'
 import LoanList from './components/LoanList.vue'
 import LoanSummary from './components/LoanSummary.vue'
@@ -27,6 +27,11 @@ function handleAutoDecide(id: string) {
   refreshLoans()
 }
 
+function handleDelete(id: string) {
+  deleteLoan(id)
+  refreshLoans()
+}
+
 onMounted(() => {
   refreshLoans()
 })
@@ -49,6 +54,7 @@ onMounted(() => {
         @approve="handleApprove"
         @reject="handleReject"
         @auto-decide="handleAutoDecide"
+        @delete="handleDelete"
       />
     </main>
   </div>

--- a/src/components/LoanList.vue
+++ b/src/components/LoanList.vue
@@ -10,6 +10,7 @@ const emit = defineEmits<{
   approve: [id: string]
   reject: [id: string]
   autoDecide: [id: string]
+  delete: [id: string]
 }>()
 
 function formatCurrency(value: number): string {
@@ -31,6 +32,13 @@ function formatDate(isoDate: string): string {
     month: 'short',
     day: 'numeric'
   })
+}
+
+function handleDelete(id: string): void {
+  // eslint-disable-next-line no-undef
+  if (confirm('Are you sure you want to delete this loan application? This action cannot be undone.')) {
+    emit('delete', id)
+  }
 }
 </script>
 
@@ -94,6 +102,13 @@ function formatDate(isoDate: string): string {
               >
                 ⚡
               </button>
+              <button
+                class="action-btn delete"
+                @click="handleDelete(loan.id)"
+                title="Delete"
+              >
+                🗑️
+              </button>
               <span v-if="loan.status !== 'pending'" class="no-actions">—</span>
             </td>
           </tr>
@@ -132,6 +147,17 @@ function formatDate(isoDate: string): string {
 
 .action-btn:last-child {
   margin-right: 0;
+}
+
+.action-btn.delete {
+  background-color: #dc3545;
+  color: white;
+  border: 1px solid #dc3545;
+}
+
+.action-btn.delete:hover {
+  background-color: #c82333;
+  border-color: #bd2130;
 }
 
 .no-actions {

--- a/src/services/loanService.ts
+++ b/src/services/loanService.ts
@@ -116,3 +116,18 @@ export function autoDecideLoan(id: string): void {
 
   saveLoans(loans)
 }
+
+/**
+ * Delete a loan application by ID
+ */
+export function deleteLoan(id: string): void {
+  const loans = getLoans()
+  const loanIndex = loans.findIndex(loan => loan.id === id)
+  
+  if (loanIndex === -1) {
+    throw new Error(`Loan with id ${id} not found`)
+  }
+
+  loans.splice(loanIndex, 1)
+  saveLoans(loans)
+}

--- a/tests/loanService.test.ts
+++ b/tests/loanService.test.ts
@@ -5,7 +5,8 @@ import {
   createLoanApplication,
   updateLoanStatus,
   calculateMonthlyPayment,
-  autoDecideLoan
+  autoDecideLoan,
+  deleteLoan
 } from '../src/services/loanService'
 import type { LoanApplication } from '../src/types/loan'
 
@@ -323,6 +324,42 @@ describe('loanService', () => {
 
     it('throws error for non-existent loan', () => {
       expect(() => autoDecideLoan('non-existent')).toThrow(
+        'Loan with id non-existent not found'
+      )
+    })
+  })
+
+  describe('deleteLoan', () => {
+    it('deletes existing loan', () => {
+      const loan1: LoanApplication = {
+        id: 'loan-1',
+        applicantName: 'John Doe',
+        amount: 50000,
+        termMonths: 24,
+        interestRate: 0.08,
+        status: 'pending',
+        createdAt: '2024-01-01T00:00:00.000Z'
+      }
+      const loan2: LoanApplication = {
+        id: 'loan-2',
+        applicantName: 'Jane Doe',
+        amount: 75000,
+        termMonths: 36,
+        interestRate: 0.06,
+        status: 'approved',
+        createdAt: '2024-02-01T00:00:00.000Z'
+      }
+      saveLoans([loan1, loan2])
+
+      deleteLoan('loan-1')
+
+      const loans = getLoans()
+      expect(loans).toHaveLength(1)
+      expect(loans[0]?.id).toBe('loan-2')
+    })
+
+    it('throws error for non-existent loan', () => {
+      expect(() => deleteLoan('non-existent')).toThrow(
         'Loan with id non-existent not found'
       )
     })


### PR DESCRIPTION
- Add deleteLoan function to loanService.ts
- Add delete button with confirmation dialog to LoanList.vue
- Wire up delete event handling in App.vue
- Add comprehensive tests for deleteLoan function

## Summary

_Provide a brief description of what this PR does and why._

## Changes

_List the key changes made in this PR:_
This pull request adds the ability for users to delete loan applications through the UI and ensures this feature is properly handled in the backend and tested. The changes include UI updates to display a delete button, backend logic to remove loans, and new tests to verify correct behavior and error handling.

**Feature Addition: Loan Deletion**

* Added a new `deleteLoan` function to `loanService.ts` that removes a loan by its ID and throws an error if the loan does not exist.
* Updated the UI in `LoanList.vue` to display a delete button for each loan, with confirmation before deletion, and styled the button for visibility. [[1]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR36-R42) [[2]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR105-R111) [[3]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR152-R162)

**Integration and Event Handling**

* Integrated the delete event throughout the app: added event emission in `LoanList.vue`, event handler in `App.vue`, and wired up the delete logic to refresh the loan list after deletion. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L4-R4) [[2]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR13) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R30-R34) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R57)

**Testing**

* Added unit tests for `deleteLoan` in `loanService.test.ts`, covering successful deletion and error cases for non-existent loans. [[1]](diffhunk://#diff-d5932355fcc75b580d6f49de6f1da90c33a9847325152bf2a5bbf3a1991a3464L8-R9) [[2]](diffhunk://#diff-d5932355fcc75b580d6f49de6f1da90c33a9847325152bf2a5bbf3a1991a3464R331-R366)
